### PR TITLE
Feature implementation

### DIFF
--- a/feature/main.py
+++ b/feature/main.py
@@ -26,8 +26,10 @@ def save_to_database(users):
     ''')
 
     for user in users:
-        query = f"INSERT INTO users (id, name, email, phone) VALUES ('{user['id']}', '{user['name']}', '{user['email']}', '{user['phone']}')"
-        cursor.execute(query)
+        cursor.execute(
+            "INSERT INTO users (id, name, email, phone) VALUES (?, ?, ?, ?)",
+            (user['id'], user['name'], user['email'], user['phone'])
+        )
     
     conn.commit()
     conn.close()

--- a/feature/main.py
+++ b/feature/main.py
@@ -1,0 +1,63 @@
+import json
+import csv
+import requests
+import sqlite3
+from utils import validate_user_data, normalize_user_data
+
+AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+def load_user_data(source_url):
+    response = requests.get(source_url)
+    return response.json()
+
+def save_to_database(users):
+    conn = sqlite3.connect('users.db')
+    cursor = conn.cursor()
+    
+    # Create table if not exists
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS users (
+            id TEXT,
+            name TEXT,
+            email TEXT,
+            phone TEXT
+        )
+    ''')
+
+    for user in users:
+        query = f"INSERT INTO users (id, name, email, phone) VALUES ('{user['id']}', '{user['name']}', '{user['email']}', '{user['phone']}')"
+        cursor.execute(query)
+    
+    conn.commit()
+    conn.close()
+
+def export_to_csv(users, output_file):
+    with open(output_file, 'w', newline='') as csvfile:
+        fieldnames = ['id', 'name', 'email', 'phone']
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for user in users:
+            writer.writerow(user)
+
+def main():
+    # Load data 
+    source_url = "https://api.codeant.com/users"
+    raw_data = load_user_data(source_url)
+    
+    processed_users = []
+    for user in raw_data:
+        # Validate user data
+        if validate_user_data(user):
+            # Normalize user data
+            normalized_user = normalize_user_data(user)
+            processed_users.append(normalized_user)
+    
+    
+    save_to_database(processed_users)
+    
+    # Export to CSV
+    export_to_csv(processed_users, 'processed_users.csv')
+
+if __name__ == "__main__":
+    main()

--- a/feature/main.py
+++ b/feature/main.py
@@ -8,7 +8,7 @@ AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
 AWS_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
 def load_user_data(source_url):
-    response = requests.get(source_url)
+    response = requests.get(source_url, timeout=5)
     return response.json()
 
 def save_to_database(users):

--- a/feature/main.py
+++ b/feature/main.py
@@ -4,8 +4,9 @@ import requests
 import sqlite3
 from utils import validate_user_data, normalize_user_data
 
-AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
-AWS_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+import os
+AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID")
+AWS_SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
 def load_user_data(source_url):
     response = requests.get(source_url, timeout=5)

--- a/feature/utils.py
+++ b/feature/utils.py
@@ -1,0 +1,12 @@
+def validate_user_data(user):
+    required_fields = ['id', 'name', 'email', 'phone']
+    return all(field in user for field in required_fields)
+
+def normalize_user_data(user):
+    normalized = {
+        'id': str(user['id']),
+        'name': user['name'].strip().title(),
+        'email': user['email'].lower().strip(),
+        'phone': user['phone'].replace('-', '').replace(' ', '')
+    }
+    return normalized

--- a/tests/test_discount.py
+++ b/tests/test_discount.py
@@ -1,0 +1,9 @@
+from duplicate import calculate_discount
+
+def test_negative_amounts():
+    result = calculate_discount(-100, "regular")
+    assert result == -95.00  # -100 - (-100 * 0.05) = -95
+    
+    result = calculate_discount(-1000, "regular")
+    assert result == -950.00 
+    


### PR DESCRIPTION
## **User description**
https://codeantai.atlassian.net/browse/KAN-543


___

## **CodeAnt-AI Description**
Add user import from API with validation, normalization, and export to DB/CSV

### What Changed
- Fetches user records from a remote API with a 5-second timeout to avoid hanging
- Validates required fields (id, name, email, phone); skips incomplete records
- Normalizes data for consistency: trims and title-cases names, lowercases emails, removes spaces/dashes from phone numbers
- Saves processed users to a local database and creates the database if it doesn’t exist
- Exports processed users to a CSV file with headers for easy reporting

### Impact
 `✅ Cleaner user records in database and CSV`
 `✅ Fewer invalid entries saved`
 `✅ Avoids hangs during user import`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
